### PR TITLE
feat: 为网站添加字体文件跨域支持配置

### DIFF
--- a/app/view/netlify.toml
+++ b/app/view/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-publish = "dist"
-command = "pnpm run build"
+publish = "app/view/dist"
+command = "node --max-old-space-size pnpm run build:view"
 
 [build.environment]
 NODE_VERSION = "20"

--- a/app/view/netlify.toml
+++ b/app/view/netlify.toml
@@ -9,3 +9,9 @@ NODE_VERSION = "20"
 from = "/*"
 to = "/index.html"
 status = 200
+
+[[headers]]
+  for = "/*.woff"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Content-Type = "application/font-woff"


### PR DESCRIPTION
主要变更：
- 在 netlify.toml 中为 .woff 字体文件配置跨域和内容类型
- 设置 Access-Control-Allow-Origin 为通配符，允许所有域名访问
- 明确指定字体文件的 Content-Type 为 application/font-woff