### PR TITLE
fix: 修正 Netlify 构建配置发布目录路径

### DIFF
--- a/app/view/netlify.toml
+++ b/app/view/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "dist"
-command = "node --max-old-space-size pnpm run build:view"
+command = "pnpm run build:view"
 
 [build.environment]
 NODE_VERSION = "20"

--- a/app/view/netlify.toml
+++ b/app/view/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-publish = "app/view/dist"
+publish = "dist"
 command = "node --max-old-space-size pnpm run build:view"
 
 [build.environment]


### PR DESCRIPTION
调整 netlify.toml 中的发布目录，将 app/view/dist 简化为 dist，以匹配项目的实际构建输出路径