### PR TITLE
feat: 注释掉 UnoCSS 网页字体预设

### DIFF
--- a/app/view/uno.config.ts
+++ b/app/view/uno.config.ts
@@ -20,12 +20,12 @@ export default defineConfig({
       scale: 1.2,
       warn: true,
     }),
-    presetWebFonts({
-      fonts: {
-        sans: 'DM Sans',
-        serif: 'DM Serif Display',
-        mono: 'DM Mono',
-      },
-    }),
+    // presetWebFonts({
+    //   fonts: {
+    //     sans: 'DM Sans',
+    //     serif: 'DM Serif Display',
+    //     mono: 'DM Mono',
+    //   },
+    // }),
   ],
 })


### PR DESCRIPTION
移除 presetWebFonts 配置，暂时禁用默认字体加载，为后续字体定制做准备