### PR TITLE
fix: 调整 Netlify 发布目录配置

### DIFF
--- a/app/view/netlify.toml
+++ b/app/view/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-publish = "dist"
+publish = "app/view/dist"
 command = "pnpm run build:view"
 
 [build.environment]


### PR DESCRIPTION
更新 netlify.toml 中的发布目录为 app/view/dist，确保构建输出路径与项目结构匹配